### PR TITLE
그룹 생성시 그룹 유저 미생성 이슈 수정

### DIFF
--- a/src/main/kotlin/com/hero/alignlab/event/listener/GroupEventListener.kt
+++ b/src/main/kotlin/com/hero/alignlab/event/listener/GroupEventListener.kt
@@ -3,6 +3,7 @@ package com.hero.alignlab.event.listener
 import com.hero.alignlab.domain.group.application.GroupUserService
 import com.hero.alignlab.event.model.CreateGroupEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionalEventListener
 
@@ -12,6 +13,7 @@ class GroupEventListener(
 ) {
     private val logger = KotlinLogging.logger { }
 
+    @Transactional(value = Transactional.TxType.REQUIRES_NEW)
     @TransactionalEventListener
     fun handle(event: CreateGroupEvent) {
         groupUserService.saveSync(event.group.id, event.group.ownerUid)


### PR DESCRIPTION
### 문제 원인
```kotlin
@Service
class GroupFacade(...) {
    suspend fun createGroup(user: AuthUser, request: CreateGroupRequest): CreateGroupResponse {
        return parZip(
            { groupService.existsByName(request.name) },
            { groupUserService.existsByUid(user.uid) }
        ) { existsByName, existsByUid ->
            if (existsByName) {
                throw InvalidRequestException(ErrorCode.DUPLICATE_GROUP_NAME_ERROR)
            }

            if (existsByUid) {
                throw InvalidRequestException(ErrorCode.DUPLICATE_GROUP_JOIN_ERROR)
            }

            val group = CreateGroupContext(user, request).create()

            txTemplates.writer.executes {
                val createdGroup = createGroup(user, group)
                val createdGroupTags = createGroupTag(createdGroup.id, request.tagNames)

                CreateGroupResponse.from(createdGroup, createdGroupTags)
            }
        }
    }

    fun createGroup(user: AuthUser, group: Group): Group {
        val createdGroup = groupService.saveSync(group)
        publisher.publishEvent(CreateGroupEvent(createdGroup))
        return createdGroup
    }
// 중략
}
```
```kotlin
@Component
class GroupEventListener(
    private val groupUserService: GroupUserService,
) {
    private val logger = KotlinLogging.logger { }

    @TransactionalEventListener
    fun handle(event: CreateGroupEvent) {
        groupUserService.saveSync(event.group.id, event.group.ownerUid)
    }
}
```
기존 코드에서는 CreateGroupEvent가 @TransactionalEventListener로 처리되면서 기본적으로 AFTER_COMMIT 단계에서 실행됐습니다. 그래서 그룹 생성이 끝난 후에야 이벤트 리스너가 실행됐고, 이 과정에서 groupUserService.saveSync가 제대로 실행되지 않아 데이터베이스에 저장이 안 되는 문제가 있었습니다. 이로 인해 그룹 생성과 그룹 유저 저장이 따로 처리되어 데이터가 맞지 않을 가능성이 생겼습니다.

### 방법 1 : BEFORE_COMMIT 단계에서 처리
```kotlin
@Component
class GroupEventListener(
    private val groupUserService: GroupUserService,
) {
    private val logger = KotlinLogging.logger { }

    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
    fun handle(event: CreateGroupEvent) {
        groupUserService.saveSync(event.group.id, event.group.ownerUid)
    }
}
```
`@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)`를 사용하면 이벤트 리스너가 그룹 생성 트랜잭션과 동일한 컨텍스트에서 실행되며, 트랜잭션이 커밋되기 전에 리스너가 실행되므로 그룹 유저 데이터 저장이 그룹 생성과 함께 원자적으로 처리됩니다.

### 방법 2 : 새로운 트랜잭션 생성해서 처리(채택된 방식)
```kotlin
@Component
class GroupEventListener(
    private val groupUserService: GroupUserService,
) {
    private val logger = KotlinLogging.logger { }

    @Transactional(value = Transactional.TxType.REQUIRES_NEW)
    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
    fun handle(event: CreateGroupEvent) {
        groupUserService.saveSync(event.group.id, event.group.ownerUid)
    }
}
```
`@Transactional(TxType.REQUIRES_NEW)`와 `@TransactionalEventListener`를 조합하여 이벤트 리스너가 원본 트랜잭션과 독립적으로 실행되도록 설정하였으며, 그룹 생성 트랜잭션이 성공적으로 커밋된 후 새로운 트랜잭션에서 그룹 유저 데이터를 저장하도록 구현했습니다.

원래 이벤트로 처리하는 목적에 맞게 방법 2로 코드 수정했습니다~
